### PR TITLE
Fixed a bug with postxwww() on the Request Service

### DIFF
--- a/src/app/RequestService/request.service.ts
+++ b/src/app/RequestService/request.service.ts
@@ -110,16 +110,12 @@ export class RequestService {
 
   private objToHttpParams(obj): HttpParams {
     let params: HttpParams = new HttpParams();
-    for (var key in obj) {
-      if (obj.hasOwnProperty(key)) {
+    for (var key of Object.keys(obj)) {
+      if (typeof obj[key] == "string") {
+        params = params.set(key, encodeURIComponent(obj[key]).replace(/%20/g, "+"));
         // params = params.set(key, obj[key]);
-        //This code technically works but Angular says that .set() takes
-        //Two strings only.
-        if (typeof obj[key] == "string") {
-          params = params.set(key, obj[key]);
-        } else {
-          params = params.set(key, JSON.stringify(obj[key]));
-        }
+      } else {
+        params = params.set(key, JSON.stringify(obj[key]));
       }
     }
     return params;


### PR DESCRIPTION
`objToHttpParams()` now follows more stringent rules for `application/x-www-form-urlencoded` requests